### PR TITLE
fix: filter by channel type

### DIFF
--- a/triggers/test_im_trigger.ts
+++ b/triggers/test_im_trigger.ts
@@ -22,8 +22,7 @@ const triggerDef: Trigger<typeof workflowDef.definition> = {
             statement: "{{data.text}} CONTAINS 'test1'",
           },
           {
-            statement: "{{data.channel_type}} == 'private'",
-            // statement: "{{data.channel_type}} == 'im'",
+            statement: "{{data.channel_type}} == 'dm'",
           },
         ],
       },


### PR DESCRIPTION
## Summary
@mfcarroll  the `message_posted` event trigger channel have been updated they are now `public`, `private` , `dm` and `mpdm`

This change should allow you to only trigger a workflow when a user posts a message to the apps direct message